### PR TITLE
Include Talents, Species, etc. from the Klingon Core rulebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # StarTrek2d20
 
 ## Prerequisites
-- Visual Studio 2019 (Community or higher).
+- Visual Studio 2019 (Community or higher) (optional).
 - NodeJS (v10.13.0 or higher).
 - TypeScript 3.1 or compatible version.
 
 ## Getting Started
+
+### With Visual Studio
+
 1. Open a command prompt in the WebTools/ folder and type ```npm install``` to install node modules.
 2. Open the solution in Visual Studio.
 3. Compile the project.
 
 Compiling will use webpack to generate a master script in the dist/ folder.
+
+### Without Visual Studio
+
+1. Open a command prompt in the WebTools/ folder and type ```npm install``` to install node modules.
+2. Create the master script using the ```npm run package``` command
+3. Open the index.html file in a browser
+
+The master script will be generated in the dist/ folder.
 
 ## Contributing
 Contributions are welcome. Use a PR to get your changes into the master branch.

--- a/WebTools/src/components/speciesSelection.tsx
+++ b/WebTools/src/components/speciesSelection.tsx
@@ -33,7 +33,7 @@ export class SpeciesSelection extends React.Component<ISpeciesSelectionPropertie
             const talents = s.id === Species.Changeling
                 ? <div>Morphogenic Matrix</div>
                 : s.talents.map((t, i) => {
-                    return <div key={i}>{t.name}</div>;
+                    return t.isAvailableExcludingSpecies() ? <div key={i}>{t.name}</div> : <span></span>;
                 });
 
             return (

--- a/WebTools/src/helpers/sources.ts
+++ b/WebTools/src/helpers/sources.ts
@@ -10,6 +10,7 @@
     TNG,
     DS9,
     Voyager,
+    KlingonCore,
 }
 
 class SourceViewModel {
@@ -35,6 +36,7 @@ class Sources {
         [Source.TNG]: "TNG",
         [Source.DS9]: "DS9",
         [Source.Voyager]: "Voyager",
+        [Source.KlingonCore]: "Klingon Core",
 
     };
 
@@ -49,8 +51,10 @@ class Sources {
         return sources;
     }
 
-    getSourceName(source: Source) {
-        return this._sources[source];
+    getSourceName(sources: Source[]) {
+        var result = "";
+        sources.forEach((s) => { result = (result == "") ? this._sources[s] : (result + ", " + this._sources[s]) })
+        return result;
     }
 }
 

--- a/WebTools/src/helpers/species.ts
+++ b/WebTools/src/helpers/species.ts
@@ -86,6 +86,8 @@ export enum Species {
     Zahl,
     // Voyager
     Hologram,
+    // Klingon Core
+    KlingonQuchHa
 }
 
 class NameModel {
@@ -427,7 +429,7 @@ class _Species {
             "Klingon",
             "There is a great redundancy in Klingon organs, with two livers, multiple stomachs, three lungs, and an eight-chambered heart. Their skeletal structure also has several redundancies that mitigate injuries that would prove fatal to other humanoids.",
             "Honor is More Important Than Life",
-            [TalentsHelper.getTalent("To Battle!"), TalentsHelper.getTalent("Brak'lul"), TalentsHelper.getTalent("R'uustai")],
+            [TalentsHelper.getTalent("To Battle!"), TalentsHelper.getTalent("Brak'lul"), TalentsHelper.getTalent("R'uustai"), TalentsHelper.getTalent("Warrior's Spirit"), TalentsHelper.getTalent("Killer's Instinct")],
             "",
             [
                 { type: "Male", suggestions: "Be'etor, Cheng, Mogh, Qeng, Torgh" },
@@ -1185,6 +1187,18 @@ class _Species {
             "Holograms can be programmed to any specification, though the nature of their holomatrix means that they are essentially impervious to direct physical harm – they can allow energy and objects to pass through them at will. However, they are unable to go anywhere that lacks holographic emitters that can project their image and forcefields, and those emitters can be damaged even if the holograms themselves cannot. Holograms also tend not to receive much respect or consideration from flesh-and-blood people, who see them as tools at best or annoyances at worst. Holograms may also have a second species trait, reflecting the species they were designed to emulate.",
             "Am I More Than My Programming?",
             [TalentsHelper.getTalent("Expanded Program"), TalentsHelper.getTalent("Mobile Emitter")],
+            "",
+            []),
+        [Species.KlingonQuchHa]: new SpeciesModel(
+            "Klingon (QuchHa')",
+            [Era.Enterprise, Era.OriginalSeries],
+            Source.KlingonCore,
+            "In 2154, a lethal, metagenic strain of the Levodian flu ran rampant through the Klingon Empire, infecting vast numbers of Klingons. Though a cure was eventually devised, the combination of the plague’s metagenic effects and the cure itself led to numerous physiological and genetic changes in those afflicted, most notably the dissolution of their cranial ridges and a number of neurological alterations, to a point where they somewhat resemble Humans, with these changes passed onto the descendants of those afflicted. These altered Klingons came to be known as QuchHa', \"the unhappy ones,\" for their seeming deformity, while those who escaped the plague's effects were commonly referred to as the HemQuch. Though still hardy and vigorous, the QuchHa’ tend to express the customary aggression of their culture as a ruthless cunning, and they are often regarded as less honorable and trustworthy. They join the armed forces and intelligence services in great numbers to prove their worth and gain glory as a result of this discrimination. By the early 2270s, almost all QuchHa’ had undergone corrective treatment to restore their Klingon physiology, and Klingons in later eras refuse to discuss the matter with outsiders.",
+            [Attribute.Control, Attribute.Insight, Attribute.Presence],
+            "Klingon and QuchHa'",
+            "Those Klingons affected by this metagenic plague are frequently discriminated against or regarded as cowardly, shameful, or un-Klingon in nature, a stigma that they frequently strive to disprove, or which frees them to take actions that other Klingons may not regard as proper. Their altered genetics leave them less susceptible to a number of diseases and disorders that affect Klingons but allows them to contract a number of Human diseases that Klingons are normally immune to.",
+            "",
+            [TalentsHelper.getTalent("Cruel"), TalentsHelper.getTalent("Superior Ambition"), TalentsHelper.getTalent("To Battle!"), TalentsHelper.getTalent("R'uustai"), TalentsHelper.getTalent("Warrior's Spirit"), TalentsHelper.getTalent("Killer's Instinct")],
             "",
             []),
         //[Species.Romulan]: new SpeciesModel(

--- a/WebTools/src/pages/supportingCharacterPage.tsx
+++ b/WebTools/src/pages/supportingCharacterPage.tsx
@@ -3,7 +3,7 @@ import {SetHeaderText} from '../common/extensions';
 import {character} from '../common/character';
 import {CharacterSerializer} from '../common/characterSerializer';
 import {Species, SpeciesHelper, SpeciesViewModel} from '../helpers/species';
-import {DropDownInput} from '../components/dropdownInput';
+import {DropDownInput} from '../components/dropDownInput';
 import {SupportingCharacterAttributes} from '../components/supportingCharacterAttributes';
 import {SupportingCharacterDisciplines} from '../components/supportingCharacterDisciplines';
 import {Rank, RanksHelper} from '../helpers/ranks';


### PR DESCRIPTION
This pull request includes:

- additional species
- additional talents
- changes to make the code recognize that some talents are available in multiple sources
- changes to make the code recognize that some species-specific talents come from different sources

This pull request does *not* include:

- caste
- paths for creating Klingon warrior characters
- support for talents with alternative names
- ability to create Klingon Core rules-styled PDF character sheets.