### PR TITLE
Finishing Touches Fix

### DIFF
--- a/WebTools/src/components/attributeImprovement.tsx
+++ b/WebTools/src/components/attributeImprovement.tsx
@@ -108,12 +108,10 @@ export class AttributeImprovementCollection extends React.Component<AttributeImp
     }
 
     componentDidUpdate(prevProps) {
-        console.log("Component did update.");
         if (this.props.points !== prevProps.points) {
             this._points = this.props.points;
         }
         if (this.props.mode !== prevProps.mode) {
-            console.log("Mode changed. Let's fix the state.");
             this.setState({ mode: this.props.mode });
             this.initializeAttributeContainers();
         }
@@ -162,8 +160,6 @@ export class AttributeImprovementCollection extends React.Component<AttributeImp
     }
 
     render() {
-        console.log("re-render");
-
         const attributes = this._attributes.map((a, i) => {
             return <AttributeImprovement
                 key={i}

--- a/WebTools/src/components/attributeImprovement.tsx
+++ b/WebTools/src/components/attributeImprovement.tsx
@@ -55,6 +55,7 @@ export enum AttributeImprovementCollectionMode {
     Customization,
     Academy,
     Ktarian,
+    ReadOnly,
 }
 
 interface AttributeImprovementCollectionProperties {
@@ -93,7 +94,6 @@ export class AttributeImprovementCollection extends React.Component<AttributeImp
         super(props);
 
         this._points = props.points;
-        this._attributes = [];
 
         if (character.isYoung()) {
             this._absoluteMax = 11;
@@ -103,7 +103,32 @@ export class AttributeImprovementCollection extends React.Component<AttributeImp
             this._absoluteMax--;
         }
 
-        switch (props.mode) {
+        this.initializeAttributeContainers();
+        this.state = { mode: props.mode };
+    }
+
+    componentDidUpdate(prevProps) {
+        console.log("Component did update.");
+        if (this.props.points !== prevProps.points) {
+            this._points = this.props.points;
+        }
+        if (this.props.mode !== prevProps.mode) {
+            console.log("Mode changed. Let's fix the state.");
+            this.setState({ mode: this.props.mode });
+            this.initializeAttributeContainers();
+        }
+    }
+
+    initializeAttributeContainers() {
+        this._attributes = [];
+        switch (this.props.mode) {
+            case AttributeImprovementCollectionMode.ReadOnly:
+                for (var i = 0; i < character.attributes.length; i++) {
+                    if (!this.props.filter || this.props.filter.indexOf(i) > -1) {
+                        this._attributes.push(new AttributeContainer(character.attributes[i].attribute, character.attributes[i].value, character.attributes[i].value, this._absoluteMax, false, false));
+                    }
+                }
+                break;
             case AttributeImprovementCollectionMode.Increase:
                 for (var i = 0; i < character.attributes.length; i++) {
                     if (!this.props.filter || this.props.filter.indexOf(i) > -1) {
@@ -137,6 +162,8 @@ export class AttributeImprovementCollection extends React.Component<AttributeImp
     }
 
     render() {
+        console.log("re-render");
+
         const attributes = this._attributes.map((a, i) => {
             return <AttributeImprovement
                 key={i}

--- a/WebTools/src/pages/attributesAndDisciplinesPage.tsx
+++ b/WebTools/src/pages/attributesAndDisciplinesPage.tsx
@@ -55,17 +55,16 @@ export class AttributesAndDisciplinesPage extends React.Component<IPagePropertie
     }
 
     render() {
-        const attributes = !this.state.showExcessAttrDistribution
-            ? <AttributeImprovementCollection mode={AttributeImprovementCollectionMode.Customization} points={this._attrPoints} onDone={(done) => { this.attributesDone(done); } } />
-            : this._excessAttrPoints > 0
-                ? <AttributeImprovementCollection mode={AttributeImprovementCollectionMode.Increase} points={this._excessAttrPoints} onDone={(done) => { this.attributesDone(done); } } />
-                : undefined;
+        const hasExcess = this.state.showExcessAttrDistribution || this.state.showExcessSkillDistribution;
+        const attributes = hasExcess
+                ? (this.state.showExcessAttrDistribution 
+                    ? <AttributeImprovementCollection mode={AttributeImprovementCollectionMode.Increase} points={this._excessAttrPoints} onDone={(done) => { this.attributesDone(done); } } />
+                    : <AttributeImprovementCollection mode={AttributeImprovementCollectionMode.ReadOnly} points={this._excessAttrPoints} onDone={(done) => { this.attributesDone(done); } } />)
+                : <AttributeImprovementCollection mode={AttributeImprovementCollectionMode.Customization} points={this._attrPoints} onDone={(done) => { this.attributesDone(done); } } />
 
         const disciplines = !this.state.showExcessSkillDistribution
             ? <ElectiveSkillList points={this._skillPoints} skills={character.skills.map(s => { return s.skill; }) } onUpdated={(skills) => { this._skillsDone = skills.length === this._skillPoints; } } />
             : <SkillImprovementCollection points={this._excessSkillPoints} skills={character.skills.map(s => s.skill) } onDone={(done) => { this._skillsDone = done; }} />;
-
-        const hasExcess = this.state.showExcessAttrDistribution || this.state.showExcessSkillDistribution;
 
         const description = !hasExcess
             ? "At this stage, your character is almost complete, and needs only a few final elements and adjustments. This serves as a last chance to customize the character before play."


### PR DESCRIPTION
The second-last page in the character creation flow can generally appear in two "modes":

1. When the character has accumulated values in attributes or disciplines that are higher than allowed, the page appears in an "extra points" mode, and the user must apply the excess points into other attributes.
2. Finally, the character is given some final points to allocate to attributes and disciplines. 

The first of those two modes doesn't always appear (but is more likely when creating a young character because the maximum values are less). 

Unfortunately, because of React lifecycle stuff, there can be some glitchy behaviour when evolving from one mode to the next. To mitigate the glitchy-ness, I've tweaked some of the components to update the component state and cause appropriate re-renders.